### PR TITLE
feat(nav): add Context nav link with id-badge icon

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -74,6 +74,12 @@
                     <span class="nav-text">Shelf</span>
                 </a>
             </li>
+            <li>
+                <a href="/context/" class="nav-item nav-context {% if '/context' in page.url %}active{% endif %}">
+                    <span class="icon"></span>
+                    <span class="nav-text">Context</span>
+                </a>
+            </li>
             {# <li><a href="/office-hours/" {% if '/office-hours' in page.url %}class="active"{% endif %}>Office Hours</a></li>
             <li><a href="/dx/" {% if '/dx' in page.url %}class="active"{% endif %}>DX</a></li> #}
         </ul>

--- a/src/css/nav-icons.css
+++ b/src/css/nav-icons.css
@@ -119,6 +119,18 @@
   text-rendering: optimizeLegibility;
 }
 
+/* Context icon - id-badge (matches the LinkedIn social-link icon) */
+.nav-context .icon::before {
+  font-family: 'uicons-regular-rounded';
+  content: "\f651";
+  text-rendering: optimizeLegibility;
+}
+.nav-context .icon::after {
+  font-family: 'uicons-solid-rounded';
+  content: "\f654";
+  text-rendering: optimizeLegibility;
+}
+
 /* Text styling */
 .nav-item .nav-text {
   display: inline-block;

--- a/src/sitemap.xml.njk
+++ b/src/sitemap.xml.njk
@@ -34,4 +34,10 @@ eleventyExcludeFromCollections: true
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://trag.dev/context/</loc>
+    <lastmod>{{ "now" | date("YYYY-MM-DD") }}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Adds Context as the rightmost main-nav item, linking to `/context/`
- Icon uses Flaticon UIcons `id-badge` codepoints (`\f651` regular, `\f654` solid), matching the LinkedIn social-link icon family
- Sitemap entry added at priority 0.8 alongside other top-level pages

## Test plan
- [ ] Run the site locally; confirm Context appears between Shelf and the theme toggle
- [ ] Hover Context; confirm regular → solid icon transition matches Speaking/Writing/Shelf behavior
- [ ] Click Context; confirm /context/ loads and the nav item shows the active state
- [ ] Confirm sitemap.xml renders the new /context/ entry after build
- [ ] Mobile view: verify the new nav item doesn't break the responsive layout